### PR TITLE
the set cookie method is defined for the response

### DIFF
--- a/book/Testing.markdown
+++ b/book/Testing.markdown
@@ -88,7 +88,7 @@ For example, add the following to your app to test against:
 
 Use `set_cookie` for setting and removing cookies, and the access them in your response:
 
-    set_cookie 'foo=bar'
+    response.set_cookie 'foo=bar'
     get '/'
     assert_equal 'Hello bar!', last_response.body 
 


### PR DESCRIPTION
This fails

get '/' do
  set_cookie "foo", "hello world"
end

This works

get '/' do
  response.set_cookie "foo", "hello world"
end
