### PR TITLE
Updated Models.markdown to require 'data_mapper' instead of 'datamapper'

### DIFF
--- a/book/Models.markdown
+++ b/book/Models.markdown
@@ -10,7 +10,7 @@ show started, and this example will include a 'Post' model.
 
     require 'rubygems'
     require 'sinatra'
-    require 'datamapper' # metagem, requires common plugins too.
+    require 'data_mapper' # metagem, requires common plugins too.
 
     # need install dm-sqlite-adapter
     DataMapper::setup(:default, "sqlite3://#{Dir.pwd}/blog.db")


### PR DESCRIPTION
In going through the Sinatra book, I received an error when trying to require 'datamapper'. In looking at the latest documentation on the DataMapper site, it looks like it should be 'data_mapper' instead of 'datamapper'. 
