### PR TITLE
Remove wkhtmltopdf binary gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ gem 'pdfkit'
 gem 'rake'
 gem 'redcarpet', '~> 2.0'
 gem 'sinatra'
-gem 'wkhtmltopdf-binary', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
     tilt (1.3.3)
-    wkhtmltopdf-binary (0.9.9.1)
 
 PLATFORMS
   ruby
@@ -22,4 +21,3 @@ DEPENDENCIES
   rake
   redcarpet (~> 2.0)
   sinatra
-  wkhtmltopdf-binary

--- a/book.rb
+++ b/book.rb
@@ -8,6 +8,8 @@ module Book
   OUTPUT_DIR = File.join(File.dirname(__FILE__), "output")
 
   def build(pdf=false)
+    check_if_wkhtmltopdf_is_available!
+
     doc = header
     doc << toc
     doc << content
@@ -63,5 +65,24 @@ module Book
       end
     end
     return s.join("\n\n* * *\n\n")
+  end
+
+  def check_if_wkhtmltopdf_is_available!
+    unless system('which wkhtmltopdf')
+      message = <<-EOF
+
+
+      This command needs the "wkhtmltopdf" binary to be available on the
+      system. The installation instructions for various OS platforms are
+      available at this link:
+
+      https://github.com/pdfkit/pdfkit/wiki/Installing-WKHTMLTOPDF
+
+      Please install that binary first and then run the builder. Aborting now.
+      EOF
+
+      puts message
+      exit(1)
+    end
   end
 end


### PR DESCRIPTION
- Add a message that shows up when the `wkhtmltopdf` binary is unavailable
  on the machine, with instructions where/how to install the binary.
- Abort the installation if (1) is true.
