### PR TITLE
prevent sinatra build comment to table of content

### DIFF
--- a/book/Helpers.markdown
+++ b/book/Helpers.markdown
@@ -10,7 +10,7 @@ design, you'll have to implement a partial handler yourself.
 Here is a really basic version:
 
 ```ruby
-# Usage: partial :foo
+ # Usage: partial :foo
 helpers do
   def partial(page, options={})
     haml page, options.merge!(:layout => false)
@@ -21,11 +21,11 @@ end
 A more advanced version that would handle passing local options, and looping over a hash would look like:
 
 ```ruby
-# Render the page once:
-# Usage: partial :foo
-# 
-# foo will be rendered once for each element in the array, passing in a local variable named "foo"
-# Usage: partial :foo, :collection => @my_foos    
+ # Render the page once:
+ # Usage: partial :foo
+ #
+ # foo will be rendered once for each element in the array, passing in a local variable named "foo"
+ # Usage: partial :foo, :collection => @my_foos    
 
 helpers do
   def partial(template, *args)
@@ -34,7 +34,7 @@ helpers do
     if collection = options.delete(:collection) then
       collection.inject([]) do |buffer, member|
         buffer << haml(template, options.merge(
-                                  :layout => false, 
+                                  :layout => false,
                                   :locals => {template.to_sym => member}
                                 )
                      )

--- a/book/Introduction.markdown
+++ b/book/Introduction.markdown
@@ -87,7 +87,7 @@ Sinatra is installed, how about making your first application?
 ```ruby
 require 'rubygems'
 
-# If you're using bundler, you will need to add this
+  # If you're using bundler, you will need to add this
 require 'bundler/setup'
 
 require 'sinatra'

--- a/book/Models.markdown
+++ b/book/Models.markdown
@@ -13,7 +13,7 @@ require 'rubygems'
 require 'sinatra'
 require 'data_mapper' # metagem, requires common plugins too.
 
-# need install dm-sqlite-adapter
+ # need install dm-sqlite-adapter
 DataMapper::setup(:default, "sqlite3://#{Dir.pwd}/blog.db")
 
 class Post
@@ -24,11 +24,11 @@ class Post
   property :created_at, DateTime
 end
 
-# Perform basic sanity checks and initialize all relationships
-# Call this when you've defined all your models
+ # Perform basic sanity checks and initialize all relationships
+ # Call this when you've defined all your models
 DataMapper.finalize
 
-# automatically create the post table
+ # automatically create the post table
 Post.auto_upgrade!
 ```
 

--- a/book/Organizing_your_application.markdown
+++ b/book/Organizing_your_application.markdown
@@ -27,7 +27,7 @@ well structured set of directories to hold many of the components that make up
 a larger application.  Remember that this file structure is just a suggestion.
 
 ```
-|- config.ru            # A rackup file. Load server.rb, and 
+|- config.ru            # A rackup file. Load server.rb, and
 |- server.rb            # Loads all files, is the base class
 |- app/
 \--- routes/
@@ -50,7 +50,7 @@ class Server < Sinatra::Base
   end
 end
 
-# Load all route files
+ # Load all route files
 Dir[File.dirname(__FILE___) + "/app/routes/**"].each do |route|
   require route
 end
@@ -59,7 +59,7 @@ end
 And the route files look something like:
 
 ```ruby
-# users.rb
+ # users.rb
 class Server < Sinatra::Base
   get '/users/:id' do
     erb :"users/show"
@@ -68,5 +68,3 @@ class Server < Sinatra::Base
   # more routes...
 end
 ```
-
-

--- a/book/Testing.markdown
+++ b/book/Testing.markdown
@@ -23,7 +23,7 @@ testing.
 Imagine you have an application like this:
 
 ```ruby
-# myapp.rb
+ # myapp.rb
 require 'sinatra'
 
 get '/' do
@@ -39,7 +39,7 @@ You have to define an `app` method pointing to your application class (which is
 `Sinatra::Application` per default):
 
 ```ruby
-begin 
+begin
   # try to use require_relative first
   # this only works for 1.9
   require_relative 'my-app.rb'
@@ -58,7 +58,7 @@ class MyAppTest < Test::Unit::TestCase
   def app
     Sinatra::Application
   end
-  
+
   def test_my_default
     get '/'
     assert last_response.ok?
@@ -101,7 +101,7 @@ Use `set_cookie` for setting and removing cookies, and the access them in your r
 ```ruby
 response.set_cookie 'foo=bar'
 get '/'
-assert_equal 'Hello bar!', last_response.body 
+assert_equal 'Hello bar!', last_response.body
 ```
 
 ### Asserting Expectations About The Response
@@ -171,5 +171,3 @@ end
 
 Now all `TestCase` subclasses will automatically have `Rack::Test`
 available to them.
-
-

--- a/book/Views.markdown
+++ b/book/Views.markdown
@@ -44,7 +44,7 @@ Here's an example of using CoffeeScript with Sinatra's template rendering
 engine Tilt:
 
 ```ruby
-## You'll need to require coffee-script in your app
+ ## You'll need to require coffee-script in your app
 require 'coffee-script'
 
 get '/application.js' do
@@ -75,14 +75,14 @@ namespace :js do
   task :compile do
     source = "#{File.dirname(__FILE__)}/src/"
     javascripts = "#{File.dirname(__FILE__)}/public/javascripts/"
-    
+
     Dir.foreach(source) do |cf|
-      unless cf == '.' || cf == '..' 
-        js = CoffeeScript.compile File.read("#{source}#{cf}") 
+      unless cf == '.' || cf == '..'
+        js = CoffeeScript.compile File.read("#{source}#{cf}")
         open "#{javascripts}#{cf.gsub('.coffee', '.js')}", 'w' do |f|
           f.puts js
-        end 
-      end 
+        end
+      end
     end
   end
 end
@@ -107,4 +107,3 @@ in your application, these are a great place to start:
 [rake]: http://rake.rubyforge.org/
 [nodejs]: http://nodejs.org/
 [ruby-coffee-script]: http://github.com/josh/ruby-coffee-script
-


### PR DESCRIPTION
when comment head no backspace, Sinatra will build it to table of content, so i  add a backspace.
