### PR TITLE
Upgrade Ruby & Add dockerfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.4'
+ruby '2.7.2'
 
 gem 'pdfkit'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,3 +23,9 @@ DEPENDENCIES
   redcarpet (~> 2.0)
   sinatra
   wkhtmltopdf-binary
+
+RUBY VERSION
+   ruby 2.7.2p137
+
+BUNDLED WITH
+   2.2.9

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.4
+FROM ruby:2.7.2
 
 WORKDIR /app
 
@@ -6,6 +6,6 @@ COPY . .
 
 RUN bundle install
 
-CMD rackup
+CMD bundle exec rackup
 
 EXPOSE 9292

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.2.4
+
+WORKDIR /app
+
+COPY . .
+
+RUN bundle install
+
+CMD rackup
+
+EXPOSE 9292


### PR DESCRIPTION
* Fix BUG: https://github.com/sinatra/sinatra-book/issues/72 Old version cannot download PDF file.Upgrade Ruby version , it works.
* Add Feature: Also add dockerfile, so we can run it in docker.